### PR TITLE
Sensitive configuration settings removed from .git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .sass-cache
 .secret
 *.css.map
+secrets.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,10 @@ module.exports = function(grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
 
+        // secrets.json is ignored in git because it contains sensitive data
+        // See the README for configuration settings
+        secrets: grunt.file.readJSON('secrets.json'),
+
 
 
 
@@ -83,7 +87,7 @@ module.exports = function(grunt) {
         mailgun: {
           mailer: {
             options: {
-              key: 'MAILGUN_KEY', // Enter your Mailgun API key here
+              key: '<%= secrets.mailgun.api_key %>', // See README for secrets.json
               sender: 'me@me.com', // Change this
               recipient: 'you@you.com', // Change this
               subject: 'This is a test email'
@@ -99,8 +103,8 @@ module.exports = function(grunt) {
         // Use Rackspace Cloud Files if you're using images in your email
         cloudfiles: {
           prod: {
-            'user': 'Rackspace Cloud Username', // Change this
-            'key': 'Rackspace Cloud API Key', // Change this
+            'user': '<%= secrets.cloudfiles.user %>', // See README for secrets.json
+            'key': '<%= secrets.cloudfiles.key %>', // See README for secrets.json
             'region': 'ORD', // Might need to change this
             'upload': [{
               'container': 'Files Container Name', // Change this
@@ -135,8 +139,8 @@ module.exports = function(grunt) {
           test: {
             src: ['dist/'+grunt.option('template')],
             options: {
-              username: 'username', // Change this
-              password: 'password', // Change this
+              username: '<%= secrets.litmus.username %>', // See README for secrets.json
+              password: '<%= secrets.litmus.password %>', // See README for secrets.json
               url: 'https://yourcompany.litmus.com', // Change this
               clients: ['android4', 'aolonline', 'androidgmailapp', 'aolonline', 'ffaolonline',
               'chromeaolonline', 'appmail6', 'iphone6', 'ipadmini', 'ipad', 'chromegmailnew',

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,30 @@ npm install
 grunt
 ```
 
+### Sensitive Information
+We encourage you __not__ to store sensitive data in your git repository. If you must, please look into [git-encrypt](https://github.com/shadowhand/git-encrypt) or some other method of encrypting your configuration secrets.
+
+1. Create a file `secrets.json` in your project root.
+2. Paste the following sample code in `secrets.json` and enter the appropriate credentials for the services you want to connect with. It's ok to leave these defaults, but they should exist.
+
+```
+{
+  "mailgun": {
+    "api_key": "YOUR MG PRIVATE API KEY"
+  },
+  "litmus": {
+    "username": "LITMUS USER NAME",
+    "password": "LITMUS PASS"
+  },
+  "cloudfiles": {
+    "user": "CLOUDFILES USERNAME",
+    "key": "CLOUDFILES KEY"
+  }
+}
+```
+
+
+
 ## How it works
 
 <img src="http://i.imgur.com/yrHpTdr.jpg" width="500">


### PR DESCRIPTION
Discourages folks from storing sensitive data in their git repos.

* Ignores `secrets.json`
* Updates `Gruntfile.js` to use `secrets.json` configuration settings
* Updates README with appropriate "Getting Started" notes for using secrets